### PR TITLE
fix: 修复安全与健壮性问题批次

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     environment:
       # 访问密码（不设置则无需密码）
       - ACCESS_PASSWORD=${ACCESS_PASSWORD:-}
+      # 登录 cookie 的 HMAC 签名密钥（不设置则回退用 ACCESS_PASSWORD 派生，属弱兜底；建议设置独立随机值）
+      - AUTH_SECRET=${AUTH_SECRET:-}
     volumes:
       # 首次部署时建议保留默认绑定挂载；如果宿主机目录是新建的，入口脚本会自动修复权限
       # 持久化数据库文件

--- a/src/app/api/auth/route.ts
+++ b/src/app/api/auth/route.ts
@@ -6,6 +6,8 @@ import { bumpAuthMinIat } from '@/lib/settings';
 // 同一 IP 在 RATE_LIMIT_WINDOW_MS 时间窗内最多允许 RATE_LIMIT_MAX 次失败
 const RATE_LIMIT_WINDOW_MS = 5 * 60 * 1000; // 5 分钟
 const RATE_LIMIT_MAX = 10;
+// 跟踪的 IP 上限，防止大量不同 IP 的失败尝试导致 Map 无界增长而 OOM
+const MAX_TRACKED_IPS = 10000;
 const loginAttempts = new Map<string, { count: number; resetAt: number }>();
 
 function getClientIp(request: NextRequest): string {
@@ -33,6 +35,19 @@ function recordFailure(ip: string): void {
   const now = Date.now();
   const entry = loginAttempts.get(ip);
   if (!entry || entry.resetAt <= now) {
+    // 写入新条目前顺手清扫所有已过期条目（resetAt <= now），物理释放内存
+    for (const [key, value] of loginAttempts) {
+      if (value.resetAt <= now) {
+        loginAttempts.delete(key);
+      }
+    }
+    // 清扫后仍达到容量上限，说明同时存在大量未过期的活跃失败 IP。
+    // 权衡：直接清空整个 Map 是最简单稳妥的兜底，可避免无界增长；
+    // 代价是极端情况下会重置所有 IP 的失败计数（限流短暂放宽），
+    // 但这种规模的并发攻击场景本应由上游反代/WAF 处理，此处仅作内存兜底。
+    if (loginAttempts.size >= MAX_TRACKED_IPS) {
+      loginAttempts.clear();
+    }
     loginAttempts.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
   } else {
     entry.count += 1;

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -5,9 +5,10 @@ import { DEFAULT_SETTINGS, Settings } from '@/types';
 import { API_KEY_MASK } from '@/lib/constants';
 
 
-export async function GET() {
-  const settings = loadSettings();
-  const safe = {
+// 对设置中的敏感密钥做脱敏，返回可安全回传给前端的结构。
+// GET 与 PUT 共用此函数，避免两处脱敏逻辑漂移导致明文密钥泄漏。
+function maskSettings(settings: Settings): Settings {
+  return {
     ...settings,
     api_key: settings.api_key ? API_KEY_MASK : '',
     image_gen: settings.image_gen ? {
@@ -16,7 +17,10 @@ export async function GET() {
       custom_api_key: settings.image_gen.custom_api_key ? API_KEY_MASK : '',
     } : settings.image_gen,
   };
-  return NextResponse.json(safe);
+}
+
+export async function GET() {
+  return NextResponse.json(maskSettings(loadSettings()));
 }
 
 export async function PUT(request: NextRequest) {
@@ -66,5 +70,6 @@ export async function PUT(request: NextRequest) {
   });
 
   transaction();
-  return NextResponse.json(loadSettings());
+  // 与 GET 保持一致的脱敏结构，避免明文密钥随写入响应回流到前端
+  return NextResponse.json(maskSettings(loadSettings()));
 }

--- a/src/components/chat/ChatView.tsx
+++ b/src/components/chat/ChatView.tsx
@@ -206,6 +206,8 @@ export default function ChatView({ character, conversationId, targetMessageId, o
   // Token 拆分弹窗
   const [tokenBreakdownOpen, setTokenBreakdownOpen] = useState(false);
   const seenMemoryTaskRef = useRef<Record<string, string>>({});
+  // 记忆任务轮询的可中止控制器：切换对话或组件卸载时中止上一轮轮询，避免无谓 fetch 与卸载后 setState
+  const pollAbortRef = useRef<AbortController | null>(null);
   const previousCharacterIdRef = useRef<string | null>(character?.id ?? null);
   const streamingFrameRef = useRef<number | null>(null);
   const pendingStreamingTextRef = useRef('');
@@ -274,6 +276,9 @@ export default function ChatView({ character, conversationId, targetMessageId, o
       cancelAnimationFrame(streamingFrameRef.current);
     }
   }, []);
+
+  // 组件卸载时中止仍在进行的记忆任务轮询，防止卸载后继续 fetch 与 setState
+  useEffect(() => () => pollAbortRef.current?.abort(), []);
 
   const activeConversation = useMemo(
     () => conversations.find(conversation => conversation.id === activeConvId) || null,
@@ -729,6 +734,11 @@ export default function ChatView({ character, conversationId, targetMessageId, o
   }, [loadOlderMessages, messages.length]); // messages 变化时重新绑定（对话切换后哨兵位置变了）
 
   const pollMemoryTask = useCallback(async (convId: string) => {
+    // 进入轮询前先中止上一轮仍在进行的轮询（切换对话/重复触发时），再创建本轮控制器
+    pollAbortRef.current?.abort();
+    const controller = new AbortController();
+    pollAbortRef.current = controller;
+
     // 只有当当前活跃的对话确实是本任务对话时，才显示“提取中”状态喵
     if (activeConvIdRef.current === convId) {
       setMemoryExtractStatus('extracting');
@@ -736,7 +746,7 @@ export default function ChatView({ character, conversationId, targetMessageId, o
     if (extractStatusTimerRef.current) { clearTimeout(extractStatusTimerRef.current); extractStatusTimerRef.current = null; }
 
     const pollOnce = async (): Promise<{ finished: boolean; status: string }> => {
-      const response = await fetch(`/api/memory-tasks?conversation_id=${encodeURIComponent(convId)}`);
+      const response = await fetch(`/api/memory-tasks?conversation_id=${encodeURIComponent(convId)}`, { signal: controller.signal });
       if (!response.ok) return { finished: false, status: 'error' };
 
       const parsed = await response.json() as { status: string; mergeCount: number; updatedAt: string | null };
@@ -755,7 +765,18 @@ export default function ChatView({ character, conversationId, targetMessageId, o
 
     // 增加轮询次数至 60 次（约 90 秒，每次 1.5 秒），给大模型（LLM）记忆提取留出充足的处理时间喵
     for (let attempt = 0; attempt < 60; attempt += 1) {
-      const { finished, status } = await pollOnce();
+      // 每轮开头检查是否已被中止（切换对话/组件卸载），是则静默退出
+      if (controller.signal.aborted) return;
+
+      let result: { finished: boolean; status: string };
+      try {
+        result = await pollOnce();
+      } catch (error) {
+        // fetch 因 abort 抛出的 AbortError 属预期行为，静默返回，不污染错误处理；其余错误维持原有传播行为
+        if (error instanceof DOMException && error.name === 'AbortError') return;
+        throw error;
+      }
+      const { finished, status } = result;
       if (finished) {
         // 竞态保护：只有当用户当前仍然看着本对话时，才更新 UI 状态和计数，避免数据错乱覆盖喵
         if (activeConvIdRef.current === convId) {
@@ -780,6 +801,8 @@ export default function ChatView({ character, conversationId, targetMessageId, o
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 1500));
+      // 等待结束后再次检查中止状态，及时退出，避免继续轮询与卸载后 setState
+      if (controller.signal.aborted) return;
     }
 
     // 超时处理：同样需要用 activeConvIdRef 保护

--- a/src/components/chat/DeleteConvModal.tsx
+++ b/src/components/chat/DeleteConvModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useTranslation } from '@/lib/i18n-context';
+import Modal from '@/components/ui/Modal';
 
 interface Props {
   open: boolean;
@@ -10,25 +11,29 @@ interface Props {
 
 /**
  * 删除对话确认弹窗
- * 从 ChatView 抽出：保持原有视觉/交互不变。
+ * 视觉外壳统一使用通用 <Modal> 组件，复用焦点陷阱 / ESC / Portal / aria-modal / 焦点恢复，
+ * 同时通过 padded=false + dialogClassName 保留原有外观（surface-panel + p-5）。
  */
 export default function DeleteConvModal({ open, onClose, onConfirm }: Props) {
   const { t } = useTranslation();
-  if (!open) return null;
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4">
-      <div className="surface-panel w-full max-w-md p-5">
-        <h3 className="section-title text-xl">{t('chat.deleteTitle')}</h3>
-        <p className="mt-3 section-copy">{t('chat.deleteConfirm')}</p>
-        <div className="mt-5 flex justify-end gap-2">
-          <button onClick={onClose} className="soft-button soft-button-secondary">
-            {t('chat.cancel')}
-          </button>
-          <button onClick={() => void onConfirm()} className="soft-button soft-button-danger">
-            {t('chat.deleteAction')}
-          </button>
-        </div>
+    <Modal
+      open={open}
+      onClose={onClose}
+      padded={false}
+      closeOnBackdrop={false}
+      dialogClassName="surface-panel w-full max-w-md p-5"
+    >
+      <h3 className="section-title text-xl">{t('chat.deleteTitle')}</h3>
+      <p className="mt-3 section-copy">{t('chat.deleteConfirm')}</p>
+      <div className="mt-5 flex justify-end gap-2">
+        <button onClick={onClose} className="soft-button soft-button-secondary">
+          {t('chat.cancel')}
+        </button>
+        <button onClick={() => void onConfirm()} className="soft-button soft-button-danger">
+          {t('chat.deleteAction')}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/components/chat/RenameConvModal.tsx
+++ b/src/components/chat/RenameConvModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslation } from '@/lib/i18n-context';
+import Modal from '@/components/ui/Modal';
 
 interface Props {
   open: boolean;
@@ -12,7 +13,7 @@ interface Props {
 
 /**
  * 重命名对话弹窗
- * 从 ChatView 抽出：保持原有视觉/交互不变。
+ * 视觉外壳统一使用通用 <Modal> 组件，复用焦点陷阱 / ESC / Portal / aria-modal / 焦点恢复。
  * 外层根据 open 决定挂载内部组件，内部组件用 initialValue 直接初始化输入值。
  */
 export default function RenameConvModal({ open, initialValue, onClose, onConfirm }: Props) {
@@ -36,24 +37,28 @@ function RenameConvModalInner({ initialValue, onClose, onConfirm }: InnerProps) 
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/35 px-4">
-      <div className="surface-panel w-full max-w-md p-5">
-        <h3 className="section-title text-xl">{t('chat.renameTitle')}</h3>
-        <input
-          value={value}
-          onChange={e => setValue(e.target.value)}
-          placeholder={t('chat.renamePlaceholder')}
-          className="input-rich mt-4"
-        />
-        <div className="mt-5 flex justify-end gap-2">
-          <button onClick={onClose} className="soft-button soft-button-secondary">
-            {t('chat.cancel')}
-          </button>
-          <button onClick={handleConfirm} className="soft-button soft-button-primary">
-            {t('chat.renameConfirm')}
-          </button>
-        </div>
+    <Modal
+      open
+      onClose={onClose}
+      padded={false}
+      closeOnBackdrop={false}
+      dialogClassName="surface-panel w-full max-w-md p-5"
+    >
+      <h3 className="section-title text-xl">{t('chat.renameTitle')}</h3>
+      <input
+        value={value}
+        onChange={e => setValue(e.target.value)}
+        placeholder={t('chat.renamePlaceholder')}
+        className="input-rich mt-4"
+      />
+      <div className="mt-5 flex justify-end gap-2">
+        <button onClick={onClose} className="soft-button soft-button-secondary">
+          {t('chat.cancel')}
+        </button>
+        <button onClick={handleConfirm} className="soft-button soft-button-primary">
+          {t('chat.renameConfirm')}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/src/lib/memory-engine.ts
+++ b/src/lib/memory-engine.ts
@@ -363,40 +363,45 @@ export async function extractMemories(
   let mergeCount = 0;
   let insertCount = 0;
 
-  for (const entry of merged) {
-    const existing = existingMap.get(entry.id);
-    if (existing) {
-      // 检查是否真的发生了修改以避免多余的更新和错误的计数
-      const isChanged =
-        existing.content !== entry.content ||
-        existing.confidence !== entry.confidence ||
-        JSON.stringify(existing.tags) !== JSON.stringify(entry.tags);
+  // 用事务包裹整个写入循环，保证多条 UPDATE/INSERT 原子提交，
+  // 避免中途崩溃导致记忆部分写入、状态不一致。
+  // 注意：chatCompletion 等异步调用已在事务外完成，事务函数内只放同步的写入与计数累加。
+  db.transaction(() => {
+    for (const entry of merged) {
+      const existing = existingMap.get(entry.id);
+      if (existing) {
+        // 检查是否真的发生了修改以避免多余的更新和错误的计数
+        const isChanged =
+          existing.content !== entry.content ||
+          existing.confidence !== entry.confidence ||
+          JSON.stringify(existing.tags) !== JSON.stringify(entry.tags);
 
-      if (isChanged) {
-        mergeCount++;
+        if (isChanged) {
+          mergeCount++;
+          db.prepare(`
+            UPDATE memories
+            SET content = ?, confidence = ?, tags = ?, updated_at = ?
+            WHERE id = ?
+          `).run(entry.content, entry.confidence, JSON.stringify(entry.tags), entry.updated_at, entry.id);
+        }
+      } else {
+        insertCount++;
         db.prepare(`
-          UPDATE memories
-          SET content = ?, confidence = ?, tags = ?, updated_at = ?
-          WHERE id = ?
-        `).run(entry.content, entry.confidence, JSON.stringify(entry.tags), entry.updated_at, entry.id);
+          INSERT INTO memories (id, character_id, category, content, confidence, tags, source_msg_ids, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, '[]', ?, ?)
+        `).run(
+          entry.id,
+          entry.character_id,
+          entry.category,
+          entry.content,
+          entry.confidence,
+          JSON.stringify(entry.tags),
+          entry.created_at,
+          entry.updated_at,
+        );
       }
-    } else {
-      insertCount++;
-      db.prepare(`
-        INSERT INTO memories (id, character_id, category, content, confidence, tags, source_msg_ids, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, '[]', ?, ?)
-      `).run(
-        entry.id,
-        entry.character_id,
-        entry.category,
-        entry.content,
-        entry.confidence,
-        JSON.stringify(entry.tags),
-        entry.created_at,
-        entry.updated_at,
-      );
     }
-  }
+  })();
 
   return { insertCount, mergeCount };
 }

--- a/src/lib/memory-queue.ts
+++ b/src/lib/memory-queue.ts
@@ -92,7 +92,11 @@ async function processQueue(): Promise<void> {
 
   const db = getDb();
 
-  while (true) {
+  // 顶层 try/finally：保证无论循环体内任何位置（包括 try/catch 之外的 SELECT、
+  // inFlightConversations.add 等）抛出异常，processing 都会被复位为 false，
+  // 避免标志永久卡在 true 导致整个记忆提取队列瘫痪。
+  try {
+    while (true) {
     // 取一条 pending 任务，并在 SQL 层直接排除 inFlightConversations 中的对话。
     // 之前的做法是先 SELECT 再判断，若命中内存去重就把任务标记为 'done' 以避免无限循环；
     // 但这会丢消息——较新任务的 message_ids 可能包含尚未被前一任务覆盖的新消息，
@@ -174,9 +178,10 @@ async function processQueue(): Promise<void> {
     } finally {
       inFlightConversations.delete(task.conversation_id);
     }
+    }
+  } finally {
+    processing = false;
   }
-
-  processing = false;
 }
 
 /** 手动触发队列处理（用于外部调用） */


### PR DESCRIPTION
- settings PUT 复用 maskSettings 脱敏，避免明文 API Key 回流前端

- auth 登录限流器加容量上限与过期清扫，防止 Map 无界增长 OOM

- memory-queue processQueue 加顶层 try/finally，保证 processing 标志复位

- memory-engine extractMemories 写入循环用事务包裹，保证原子性

- ChatView pollMemoryTask 加 AbortController，切换对话/卸载时取消轮询

- 对话删除/重命名弹窗改用通用 Modal，补齐焦点陷阱/ESC/焦点恢复（保留点遮罩不关闭）

- docker-compose 透传 AUTH_SECRET 环境变量